### PR TITLE
Mise à jour du .gitignore et nettoyage des fichiers IML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ pip-wheel-metadata/
 # ───────── Éditeurs / IDE ─────────
 .idea/
 .vscode/
+*.iml
 
 # Artefacts système
 .DS_Store

--- a/doc-chat.iml
+++ b/doc-chat.iml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module type="PYTHON_MODULE" version="4">
-  <component name="NewModuleRootManager" inherit-compiler-output="true">
-    <exclude-output />
-    <content url="file://$MODULE_DIR$" />
-    <orderEntry type="jdk" jdkName="Python 3.10 (java-doc-chat)" jdkType="Python SDK" />
-    <orderEntry type="sourceFolder" forTests="false" />
-  </component>
-</module>


### PR DESCRIPTION
## Résumé
- ajoute le motif `*.iml` dans `.gitignore`
- supprime `doc-chat.iml` du dépôt

## Test
- aucun test automatisé n'est présent dans ce dépôt

------
https://chatgpt.com/codex/tasks/task_e_687ba22512f4832eb49af7e277ecb570