### PR TITLE
Amélioration de l'intégration Ollama

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,10 @@ python app.py
 
 Une interface web s’ouvrira automatiquement.
 
+Si vous obtenez une erreur de type `RemoteProtocolError: Server disconnected`,
+assurez‑vous que le serveur **Ollama** est bien lancé via `ollama serve` ou
+`ollama run mistral` dans un autre terminal.
+
 ---
 
 ## 💬 Exemples de questions

--- a/app.py
+++ b/app.py
@@ -1,11 +1,25 @@
 import json
 from pathlib import Path
+import requests
 
 from llama_index.core import Document, VectorStoreIndex
 from llama_index.llms.ollama import Ollama
 from llama_index.embeddings.ollama import OllamaEmbedding
 from llama_index.core.settings import Settings
 import gradio as gr
+
+# ── 0) vérification du serveur Ollama ───────────────────────
+def check_ollama(url: str = "http://localhost:11434") -> None:
+    """Vérifie que le serveur Ollama est disponible."""
+    try:
+        r = requests.get(f"{url}/api/tags", timeout=5)
+        r.raise_for_status()
+    except Exception as e:
+        raise SystemExit(
+            f"Ollama semble indisponible sur {url}. Lancez `ollama serve` ou `ollama run mistral` dans un autre terminal."
+        ) from e
+
+check_ollama()
 
 # ── 1) chemin projet ────────────────────────────────────────
 with open("settings.json") as f:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ llama-index-readers-file==0.4.0
 llama-index-llms-ollama==0.6.2     # version compatible avec la branche 0.12
 llama-index-embeddings-ollama==0.5.0
 gradio==4.31.2
+requests>=2.31.0

--- a/reset-env.sh
+++ b/reset-env.sh
@@ -1,29 +1,40 @@
-  #!/bin/bash
+#!/bin/bash
 
-  set -e  # Stopper si une commande échoue
+set -e  # Stopper si une commande échoue
 
-  # 🛑 Désactiver un éventuel environnement actif
-  if [[ "$VIRTUAL_ENV" != "" ]]; then
-    echo "🔌 Désactivation de l'environnement Python actif..."
-    deactivate
-  fi
+# 🛑 Désactiver un éventuel environnement actif
+if [[ "$VIRTUAL_ENV" != "" ]]; then
+  echo "🔌 Désactivation de l'environnement Python actif..."
+  deactivate
+fi
 
-  # 🧹 Supprimer l'ancien venv
-  echo "🗑 Suppression de l'ancien .venv..."
-  rm -rf .venv
+# 🧹 Supprimer l'ancien venv
+echo "🗑 Suppression de l'ancien .venv..."
+rm -rf .venv
 
-  # 🆕 Créer un nouveau venv
-  echo "🐍 Création du nouvel environnement virtuel..."
-  python3 -m venv .venv
+# 🆕 Créer un nouveau venv
+echo "🐍 Création du nouvel environnement virtuel..."
+python3 -m venv .venv
 
-  # ✅ Activer
-  echo "✅ Activation de l'environnement..."
-  source .venv/bin/activate
+# ✅ Activer
+echo "✅ Activation de l'environnement..."
+source .venv/bin/activate
 
-  # 📦 Installer les dépendances
-  echo "📦 Installation des dépendances depuis requirements.txt..."
-  pip install --no-cache-dir -r requirements.txt
+# 📦 Installer les dépendances
+echo "📦 Installation des dépendances depuis requirements.txt..."
+pip install --no-cache-dir -r requirements.txt
 
-  # 🚀 Lancer l'application
-  echo "🚀 Lancement de l'assistant IA..."
-  python app.py
+# ▶️ Vérifier la disponibilité d'Ollama
+if ! command -v ollama >/dev/null; then
+  echo "❌ Ollama est introuvable. Installez-le puis lancez 'ollama serve'."
+  exit 1
+fi
+if ! curl -s http://localhost:11434/api/tags >/dev/null; then
+  echo "🔄 Démarrage du serveur Ollama..."
+  ollama serve >/dev/null 2>&1 &
+  sleep 5
+fi
+
+# 🚀 Lancer l'application
+echo "🚀 Lancement de l'assistant IA..."
+python app.py


### PR DESCRIPTION
## Résumé
- vérifie la disponibilité du serveur Ollama au démarrage
- ajoute `requests` dans les dépendances
- lance Ollama automatiquement depuis `reset-env.sh`
- documente l'erreur possible dans le README

## Tests
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_687ba76bc860832ead51e61f6548964e