### PR TITLE
Ajout du filtrage des dossiers via la config

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,12 +93,12 @@ cp settings.example.json settings.json
 cp settings.example.json settings.json
 ```
 
-2. Modifiez le fichier `settings.json` pour pointer vers le **chemin local** de votre projet et définir les extensions à indexer :
-
+2. Modifiez le fichier `settings.json` pour indiquer le **chemin local** du projet, les extensions à indexer et les dossiers à ignorer :
 ```json
 {
   "project_root": "../chemin/vers/mon-projet/",
-  "extensions": [".md", ".adoc"]
+  "extensions": [".md", ".adoc"],
+  "skip_dirs": [".venv"],
 }
 ```
 

--- a/app.py
+++ b/app.py
@@ -55,8 +55,11 @@ logger.debug(f"Extensions : {', '.join(sorted(exts))}")
 # ── 2) lecture fichiers ─────────────────────────────────────
 logger.debug("Étape 2 : analyse des fichiers")
 docs = []
-# Dossiers à exclure pour accélérer le scan
-skip_dirs = {".git", ".venv", "node_modules", "target"}
+# Dossiers à exclure pour accélérer le scan (paramètre `skip_dirs`)
+skip_dirs = set(cfg.get(
+    "skip_dirs",
+    [".git", ".venv", "venv", "node_modules", "target"]
+))
 for f in root.rglob("*"):
     # Ignorer les fichiers situés dans les dossiers exclus
     if any(part in skip_dirs for part in f.parts):

--- a/settings.example.json
+++ b/settings.example.json
@@ -1,4 +1,5 @@
 {
   "project_root": ".",
-  "extensions": [".md", ".adoc", ".puml"]
+  "extensions": [".md", ".adoc", ".puml"],
+  "skip_dirs": [".venv", "node_modules"]
 }


### PR DESCRIPTION
## Résumé
- ajout d'un paramètre `skip_dirs` dans `settings.example.json`
- prise en compte de `skip_dirs` dans `app.py`
- documentation mise à jour pour expliquer cette option

## Tests
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_687fe2a8899c832e90c12c6211eb98c8