### PR TITLE
Ajout de la dépendance Ollama

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ llama-index-llms-ollama==0.6.2     # version compatible avec la branche 0.12
 llama-index-embeddings-ollama==0.5.0
 gradio==4.31.2
 requests>=2.31.0
+ollama==0.1.7


### PR DESCRIPTION
## Résumé
- ajoute `ollama==0.1.7` dans `requirements.txt`

## Tests
- `pip install -r requirements.txt` *(échec : accès internet bloqué)*
- `python app.py --debug` *(échec : module `requests` manquant)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_687fed41d48c832e834cffd6b0f50455