### PR TITLE
Mise à jour du README pour accès manuel

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ Si vous obtenez une erreur de type `RemoteProtocolError: Server disconnected`,
 assurez‑vous que le serveur **Ollama** est bien lancé via `ollama serve` ou
 `ollama run mistral` dans un autre terminal.
 
+Si l'interface ne s'ouvre pas automatiquement, accédez-y via [http://localhost:7860](http://localhost:7860).
+
+Lors de la première utilisation, lancez `ollama run mistral` une fois pour télécharger le modèle localement.
+
 ---
 
 ## 💬 Exemples de questions


### PR DESCRIPTION
## Résumé
- ajout d'un rappel pour accéder à l'interface web si le navigateur ne s'ouvre pas
- rappel d'exécuter `ollama run mistral` une première fois

## Tests
- aucun test automatisé n'est fourni dans ce dépôt

------
https://chatgpt.com/codex/tasks/task_e_687fee054b40832e8d6775957ab9a371