### PR TITLE
Mise à jour de la version d'Ollama

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ llama-index-llms-ollama==0.6.2     # version compatible avec la branche 0.12
 llama-index-embeddings-ollama==0.5.0
 gradio==4.31.2
 requests>=2.31.0
-ollama==0.1.7
+ollama>=0.5.1


### PR DESCRIPTION
## Résumé
- mise à jour de la dépendance `ollama` vers une version plus récente

## Tests
- `bash reset-env.sh` *(échoue : accès internet interdit)*

------
https://chatgpt.com/codex/tasks/task_e_687fef7eafd0832ea4c4d5999e5903f7