### PR TITLE
Ajout du délai de requête configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,16 +96,19 @@ cp settings.example.json settings.json
 cp settings.example.json settings.json
 ```
 
-2. Modifiez le fichier `settings.json` pour indiquer le **chemin local** du projet, les extensions à indexer et les dossiers à ignorer :
+2. Modifiez le fichier `settings.json` pour indiquer le **chemin local** du projet, les extensions à indexer, les dossiers à ignorer et le délai maximal des requêtes :
 ```json
 {
   "project_root": "../chemin/vers/mon-projet/",
   "extensions": [".md", ".adoc"],
   "skip_dirs": [".venv"],
+  "request_timeout": 120,
 }
 ```
 
 Ce fichier est ignoré dans `.gitignore`.
+
+La clé `request_timeout` indique, en secondes, le délai d'attente maximal pour les requêtes envoyées à Ollama (120 par défaut).
 
 ---
 

--- a/app.py
+++ b/app.py
@@ -47,10 +47,13 @@ with open("settings.json") as f:
 root = Path(cfg["project_root"]).resolve()
 # Extensions à prendre en compte, exemple : [".md", ".adoc"]
 exts = {e.lower() for e in cfg.get("extensions", [".md", ".adoc", ".puml"])}
+# Délai maximal pour les requêtes vers Ollama
+timeout = cfg.get("request_timeout", 120)
 if not root.exists():
     raise FileNotFoundError(root)
 logger.debug(f"Racine du projet : {root}")
 logger.debug(f"Extensions : {', '.join(sorted(exts))}")
+logger.debug(f"Timeout Ollama : {timeout}s")
 
 # ── 2) lecture fichiers ─────────────────────────────────────
 logger.debug("Étape 2 : analyse des fichiers")
@@ -80,8 +83,8 @@ logger.debug(f"{len(docs)} fichiers chargés")
 
 # ── 3) config 100 % locale ──────────────────────────────────
 logger.debug("Étape 3 : configuration des modèles")
-Settings.llm         = Ollama(model="mistral")
-Settings.embed_model = OllamaEmbedding(model_name="mistral")
+Settings.llm         = Ollama(model="mistral", request_timeout=timeout)
+Settings.embed_model = OllamaEmbedding(model_name="mistral", request_timeout=timeout)
 
 # ── 4) index & moteur ───────────────────────────────────────
 logger.debug("Étape 4 : création de l'index")

--- a/settings.example.json
+++ b/settings.example.json
@@ -1,5 +1,6 @@
 {
   "project_root": ".",
   "extensions": [".md", ".adoc", ".puml"],
-  "skip_dirs": [".venv", "node_modules"]
+  "skip_dirs": [".venv", "node_modules"],
+  "request_timeout": 120
 }


### PR DESCRIPTION
## Résumé
- prise en charge d'un paramètre `request_timeout` dans `settings.example.json`
- lecture de ce paramètre dans `app.py` avec 120 secondes par défaut
- passage du délai à `Ollama` et `OllamaEmbedding`
- documentation de ce réglage dans le README

## Tests
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68823a425998832e8f0691145ccebb9c