### PR TITLE
Ajout d'un script reset-env pour Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,9 @@ ollama run mistral
 python app.py
 ```
 
+Pour automatiser cette procédure, utilisez `reset-env.sh` sous Linux ou macOS,
+et `reset-env.cmd` sous Windows.
+
 ---
 
 ## ✅ Compatible avec Windows, Linux, macOS

--- a/reset-env.cmd
+++ b/reset-env.cmd
@@ -1,0 +1,44 @@
+@echo off
+REM ── Arrête le script si une commande échoue ─────────
+
+REM 🛑 Désactiver un éventuel environnement actif
+if defined VIRTUAL_ENV (
+    echo 🔌 Désactivation de l'environnement Python actif...
+    call deactivate
+)
+
+REM 🧹 Supprimer l'ancien venv
+echo 🗑 Suppression de l'ancien .venv...
+if exist .venv rmdir /s /q .venv
+
+REM 🆕 Créer un nouveau venv
+echo 🐍 Création du nouvel environnement virtuel...
+python -m venv .venv
+if errorlevel 1 exit /b 1
+
+REM ✅ Activer
+echo ✅ Activation de l'environnement...
+call .venv\Scripts\activate.bat
+
+REM 📦 Installer les dépendances
+echo 📦 Installation des dépendances depuis requirements.txt...
+pip install --proxy http://127.0.0.1:8888 --trusted-host pypi.org --trusted-host files.pythonhosted.org --disable-pip-version-check --no-cache-dir -r requirements.txt
+if errorlevel 1 exit /b 1
+
+REM ▶️ Vérifier la disponibilité d'Ollama
+where ollama >nul 2>nul
+if errorlevel 1 (
+    echo ❌ Ollama est introuvable. Installez-le puis lancez 'ollama serve'.
+    exit /b 1
+)
+
+curl -s http://localhost:11434/api/tags >nul 2>nul
+if errorlevel 1 (
+    echo 🔄 Démarrage du serveur Ollama...
+    start /b "" ollama serve >nul 2>&1
+    timeout /t 5 >nul
+)
+
+REM 🚀 Lancer l'application
+echo 🚀 Lancement de l'assistant IA...
+python app.py --debug


### PR DESCRIPTION
## Résumé
- ajouter `reset-env.cmd` pour recréer l'environnement sous Windows
- documenter son utilisation dans le README

## Tests
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6887479c2f80832ea236075a5c6cb8f6