### PR TITLE
Désactive la télémétrie Gradio

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,12 @@ Si l'interface ne s'ouvre pas automatiquement, accédez-y via [http://localhost:
 
 Lors de la première utilisation, lancez `ollama run mistral` une fois pour télécharger le modèle localement.
 
+Afin d’empêcher tout trafic sortant, Gradio peut envoyer des statistiques
+d’utilisation vers Hugging Face. Ce comportement se désactive en ajoutant
+`analytics_enabled=False` dans `app.py` et/ou en définissant la variable
+d’environnement `GRADIO_ANALYTICS_ENABLED=false` avant de lancer
+l’application.
+
 ---
 
 ## 💬 Exemples de questions

--- a/app.py
+++ b/app.py
@@ -28,6 +28,10 @@ logger = logging.getLogger(__name__)
 for var in ["HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"]:
     os.environ.pop(var, None)
 
+# désactiver la télémétrie pour empêcher toute connexion sortante
+os.environ["GRADIO_ANALYTICS_ENABLED"] = "false"
+os.environ["HF_HUB_DISABLE_TELEMETRY"] = "1"
+
 
 # ── 0) vérification du serveur Ollama ───────────────────────
 def check_ollama(url: str = "http://localhost:11434") -> None:
@@ -106,4 +110,5 @@ def chat(q): return str(engine.query(q))
 
 logger.debug("Étape 5 : lancement de l'interface web")
 gr.Interface(chat, "text", "text",
-             title="Assistant IA – Doc projet Java").launch()
+             title="Assistant IA – Doc projet Java").launch(
+    share=False, analytics_enabled=False)


### PR DESCRIPTION
## Summary
- empêche les connexions sortantes en désactivant la télémétrie de Gradio
- documente cette option dans le README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688775cac378832e8bd56405ed6546ac