### PR TITLE
Add timeout hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ cp settings.example.json settings.json
 
 Ce fichier est ignoré dans `.gitignore`.
 
-La clé `request_timeout` indique, en secondes, le délai d'attente maximal pour les requêtes envoyées à Ollama (120 par défaut).
+La clé `request_timeout` indique, en secondes, le délai d'attente maximal pour les requêtes envoyées à Ollama (120 par défaut). Si vous obtenez une erreur `ReadTimeout` lors d'une question, augmentez simplement cette valeur (par exemple `300`).
 
 ---
 

--- a/app.py
+++ b/app.py
@@ -62,6 +62,8 @@ root = Path(cfg["project_root"]).resolve()
 # Extensions à prendre en compte, exemple : [".md", ".adoc"]
 exts = {e.lower() for e in cfg.get("extensions", [".md", ".adoc", ".puml"])}
 # Délai maximal pour les requêtes vers Ollama
+# Augmentez ce délai dans `settings.json` si vous rencontrez des erreurs
+# `ReadTimeout` lors des appels au modèle.
 timeout = cfg.get("request_timeout", 120)
 if not root.exists():
     raise FileNotFoundError(root)


### PR DESCRIPTION
## Summary
- document how to increase request_timeout
- add inline comment in `app.py` about timeout

## Testing
- `pre-commit` *(fails: Could not run due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68878d205388832e989754bf147cb0a1