### PR TITLE
Ajout message d'attente et barre de progression

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,6 +5,13 @@ import argparse
 import logging
 import os
 
+try:
+    from tqdm import tqdm  # barre de progression optionnelle
+except Exception:
+    # si tqdm n'est pas installé, on définit un simple pass-through
+    def tqdm(it, *args, **kwargs):
+        return it
+
 from llama_index.core import Document, VectorStoreIndex
 from llama_index.llms.ollama import Ollama
 from llama_index.embeddings.ollama import OllamaEmbedding
@@ -79,7 +86,7 @@ skip_dirs = set(cfg.get(
     "skip_dirs",
     [".git", ".venv", "venv", "node_modules", "target"]
 ))
-for f in root.rglob("*"):
+for f in tqdm(root.rglob("*"), desc="Analyse des fichiers"):
     # Ignorer les fichiers situés dans les dossiers exclus
     if any(part in skip_dirs for part in f.parts):
         continue
@@ -104,6 +111,7 @@ Settings.embed_model = OllamaEmbedding(model_name="mistral", request_timeout=tim
 
 # ── 4) index & moteur ───────────────────────────────────────
 logger.debug("Étape 4 : création de l'index")
+print("\u23F3 Génération de l'index, cela peut durer plusieurs minutes…")
 index  = VectorStoreIndex.from_documents(docs)     # Settings déjà peuplé
 engine = index.as_query_engine()
 


### PR DESCRIPTION
## Résumé
- ajoute l'import facultatif de `tqdm` avec repli si absent
- affiche une barre de progression durant l'analyse des fichiers
- avertit l'utilisateur que la génération de l'index peut prendre plusieurs minutes

## Testing
- `python app.py --debug` *(échoue : ModuleNotFoundError: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_e_6888ab9696bc832eb97de0a97934528f