### PR TITLE
Ajout du paramètre base_url

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,12 +103,15 @@ cp settings.example.json settings.json
   "extensions": [".md", ".adoc"],
   "skip_dirs": [".venv"],
   "request_timeout": 120,
+  "base_url": "http://localhost:11434",
 }
 ```
 
 Ce fichier est ignoré dans `.gitignore`.
 
 La clé `request_timeout` indique, en secondes, le délai d'attente maximal pour les requêtes envoyées à Ollama (120 par défaut). Si vous obtenez une erreur `ReadTimeout` lors d'une question, augmentez simplement cette valeur (par exemple `300`).
+
+La clé `base_url` permet de spécifier l'URL du serveur **Ollama** si celui-ci n'est pas accessible sur `http://localhost:11434`.
 
 ---
 

--- a/app.py
+++ b/app.py
@@ -37,6 +37,7 @@ for var in ["HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"]:
 
 # désactiver la télémétrie pour empêcher toute connexion sortante
 os.environ["GRADIO_ANALYTICS_ENABLED"] = "false"
+# désactiver la télémétrie pour empêcher toute connexion sortante
 os.environ["HF_HUB_DISABLE_TELEMETRY"] = "1"
 
 
@@ -57,13 +58,16 @@ def check_ollama(url: str = "http://localhost:11434") -> None:
         ) from e
     logger.debug("Serveur Ollama prêt")
 
-logger.debug("Étape 0 : vérification du serveur")
-check_ollama()
-
 # ── 1) chemin projet ────────────────────────────────────────
 logger.debug("Étape 1 : lecture de la configuration")
 with open("settings.json") as f:
     cfg = json.load(f)
+
+base_url = cfg.get("base_url", "http://localhost:11434")
+logger.debug(f"Base URL Ollama : {base_url}")
+
+logger.debug("Étape 0 : vérification du serveur")
+check_ollama(base_url)
 
 root = Path(cfg["project_root"]).resolve()
 # Extensions à prendre en compte, exemple : [".md", ".adoc"]
@@ -106,8 +110,8 @@ logger.debug(f"{len(docs)} fichiers chargés")
 
 # ── 3) config 100 % locale ──────────────────────────────────
 logger.debug("Étape 3 : configuration des modèles")
-Settings.llm         = Ollama(model="mistral", request_timeout=timeout)
-Settings.embed_model = OllamaEmbedding(model_name="mistral", request_timeout=timeout)
+Settings.llm         = Ollama(model="mistral", base_url=base_url, request_timeout=timeout)
+Settings.embed_model = OllamaEmbedding(model_name="mistral", base_url=base_url, request_timeout=timeout)
 
 # ── 4) index & moteur ───────────────────────────────────────
 logger.debug("Étape 4 : création de l'index")

--- a/settings.example.json
+++ b/settings.example.json
@@ -2,5 +2,6 @@
   "project_root": ".",
   "extensions": [".md", ".adoc", ".puml"],
   "skip_dirs": [".venv", "node_modules"],
-  "request_timeout": 120
+  "request_timeout": 120,
+  "base_url": "http://localhost:11434"
 }


### PR DESCRIPTION
## Résumé
- ajout de la clé `base_url` à la configuration exemple
- lecture de cette clé dans `app.py`
- transmission de `base_url` aux modèles Ollama
- documentation sur ce nouveau paramètre

## Tests
- `python -m py_compile app.py`
- `pip install -r requirements.txt` *(échoue : tunnel 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6888ad7b0308832eb1fcbba20af56bb3